### PR TITLE
Support NFElectrical reactors

### DIFF
--- a/GameData/KerbalismConfig/Support/NearFuture.cfg
+++ b/GameData/KerbalismConfig/Support/NearFuture.cfg
@@ -162,8 +162,18 @@ Profile
 	// Note: 1000 mrem is 1 rad
 	// Note: Assume that shielding improves for larger reactors, and thus radiation is constant for all reactor types
 
-@PART[reactor-*]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
+@PART[*]:HAS[@MODULE[FissionGenerator],@MODULE[FissionReactor]]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
+	MODULE
+	{
+		name = ProcessController
+		resource = _Nukereactor
+		title = Fission reactor
+		capacity = #$../MODULE[FissionGenerator]/PowerGeneration$
+		// capacity=1 means 10kW
+		@capacity /= 10
+	}
+
 	!MODULE[FissionGenerator],* {}
 	!MODULE[FissionReactor],* {}
 	!MODULE[ModuleCoreHeatNoCatchup],* {}
@@ -173,14 +183,6 @@ Profile
 	{
 		name = Emitter
 		radiation = 0.000003 // rad/s
-	}
-
-	MODULE
-	{
-		name = ProcessController
-		resource = _Nukereactor
-		title = Fission reactor
-		capacity = 1
 	}
 
 	MODULE:NEEDS[FeatureReliability]
@@ -194,36 +196,6 @@ Profile
 		extra_cost = 2.5
 		extra_mass = 1.0
 	}
-}
-
-@PART[reactor-0625]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
-{
-	@MODULE[ProcessController]:HAS[#title[Fission?reactor]]{@capacity *= 6.0}  // 60 EC
-}
-
-@PART[reactor-125]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
-{
-	@MODULE[ProcessController]:HAS[#title[Fission?reactor]]{@capacity *= 40.0}  // 400 EC
-}
-
-@PART[reactor-25]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
-{
-	@MODULE[ProcessController]:HAS[#title[Fission?reactor]]{@capacity *= 200.0}  // 2000 EC
-}
-
-@PART[reactor-25-2]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
-{
-	@MODULE[ProcessController]:HAS[#title[Fission?reactor]]{@capacity *= 300.0}  // 3000 EC
-}
-
-@PART[reactor-375]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
-{
-	@MODULE[ProcessController]:HAS[#title[Fission?reactor]]{@capacity *= 200.0}  // 2000 EC
-}
-
-@PART[reactor-375-2]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
-{
-	@MODULE[ProcessController]:HAS[#title[Fission?reactor]]{@capacity *= 600.0}  // 6000 EC
 }
 
 // ============================================================================
@@ -460,7 +432,7 @@ RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileDefault]
 	isVisible = false
 }
 
-RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileDefault]
+RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileRealismOverhaul]
 {
 	name = _Nukereactor
 	density = 0.0


### PR DESCRIPTION
- assign to RO profile
- apply to any part that has the right modules, instead of
  itemizing part names; RO creates a few extra parts
- derive capacity from part's RO-configured EC output instead
  of hardcoding

A couple of reactors don't work out of the box because they come
with a supply of UraniumNitride instead of EnrichedUranium; they
can work with a Nuclear Fuel Drum, so good enough for now.
Presumably should get a different process.